### PR TITLE
feat(command): :children_crossing: add cursor preview for commands

### DIFF
--- a/src/classes/command.ts
+++ b/src/classes/command.ts
@@ -7,15 +7,25 @@ export interface Commandable {
 export class Command implements Commandable {
   readonly name: string;
   readonly icon: string;
+  readonly cursor: string;
+  readonly isDrawable: boolean;
 
   readonly clickStart: (position: { x: number; y: number }) => void;
   readonly clickEnd: (position: { x: number; y: number }) => void;
   readonly drag: (position: { x: number; y: number }) => void;
   // lastPoint: { x: number | null; y: number | null };
 
-  constructor(data: { name: string; icon: string; commandable: Commandable }) {
+  constructor(data: {
+    name: string;
+    icon: string;
+    cursor: string;
+    isDrawable?: boolean;
+    commandable: Commandable;
+  }) {
     this.name = data.name;
     this.icon = data.icon;
+    this.cursor = data.cursor;
+    this.isDrawable = data.isDrawable ?? true;
     this.clickStart = data.commandable.clickStart;
     this.clickEnd = data.commandable.clickEnd;
     this.drag = data.commandable.drag;

--- a/src/components/TheBase.vue
+++ b/src/components/TheBase.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import { useStore } from "../stores";
 import TheCanvas from "./TheCanvas.vue";
 import TheToolbar from "./TheToolbar.vue";
+
+const store = useStore();
 </script>
 
 <template>
-  <div class="bg-slate-200 flex grow justify-center items-center">
+  <div
+    class="bg-slate-200 flex grow justify-center items-center"
+    :style="{ cursor: store.currentCommand.cursor }"
+  >
     <TheToolbar></TheToolbar>
     <TheCanvas></TheCanvas>
   </div>

--- a/src/components/TheCanvas.vue
+++ b/src/components/TheCanvas.vue
@@ -6,7 +6,7 @@ import { useStore } from "../stores";
 
 const store = useStore();
 const canvas = ref<HTMLCanvasElement>();
-// const lastPoint = ref<{ x: number; y: number }>();
+const cursorPosition = ref<{ x: number; y: number }>({ x: 0, y: 0 });
 
 const render = debounce(() => {
   const ctx = canvas.value!.getContext("2d");
@@ -21,6 +21,20 @@ const render = debounce(() => {
   // ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
   ctx.canvas.width = ctx.canvas.width;
   ctx.drawImage(buffer, 0, 0);
+  const tempPosition = calculateRelativePosition(
+    cursorPosition.value as MouseEvent
+  );
+
+  if (store.currentCommand.isDrawable) {
+    ctx.fillStyle = store.currentColor.hex;
+    ctx.fillRect(
+      tempPosition.x - (tempPosition.x % store.scale),
+      tempPosition.y - (tempPosition.y % store.scale),
+      store.scale,
+      store.scale
+    );
+  }
+
   requestAnimationFrame(render);
   // buffer.remove();
 }, 50);
@@ -58,6 +72,13 @@ const handleClick = (event: MouseEvent) => {
   document.addEventListener("mousemove", handleMouseMove);
   document.addEventListener("mouseup", handleMouseUp);
 };
+
+document.addEventListener(
+  "mousemove",
+  debounce((event: MouseEvent) => {
+    cursorPosition.value = { x: event?.x ?? 0, y: event?.y ?? 0 };
+  }, 5)
+);
 
 onUpdated(render);
 onMounted(render);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -47,6 +47,7 @@ export const useStore = defineStore("index", {
   },
 
   getters: {
+    currentCommand: (state) => state.command[state.currentCommandIndex],
     currentColor: (state) => {
       return state.palette[state.selectedPalette][state.selectedColor];
     },
@@ -97,6 +98,8 @@ export const useStore = defineStore("index", {
         new Command({
           name: "펜",
           icon: "edit",
+          cursor:
+            "url('https://api.iconify.design/pixelarticons/edit.svg') 0 16, auto",
           commandable: {
             clickStart: drawPen,
             clickEnd: () => {},
@@ -108,6 +111,9 @@ export const useStore = defineStore("index", {
         new Command({
           name: "지우개",
           icon: "layout-sidebar-left",
+          cursor:
+            "url('https://api.iconify.design/pixelarticons/layout-sidebar-left.svg') 0 8, auto",
+          isDrawable: false,
           commandable: {
             clickStart: erasePen,
             clickEnd: () => {},
@@ -119,6 +125,7 @@ export const useStore = defineStore("index", {
         new Command({
           name: "직선(구현X)",
           icon: "minus",
+          cursor: "crosshair",
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},
@@ -130,6 +137,7 @@ export const useStore = defineStore("index", {
         new Command({
           name: "직사각형(구현X)",
           icon: "checkbox-on",
+          cursor: "crosshair",
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},
@@ -141,6 +149,7 @@ export const useStore = defineStore("index", {
         new Command({
           name: "원(구현X)",
           icon: "circle",
+          cursor: "crosshair",
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},
@@ -151,7 +160,9 @@ export const useStore = defineStore("index", {
       this.command.push(
         new Command({
           name: "채우기(구현X)",
-          icon: "fill",
+          icon: "fill-half",
+          cursor:
+            "url('https://api.iconify.design/pixelarticons/fill-half.svg') 16 16, auto",
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},
@@ -163,6 +174,8 @@ export const useStore = defineStore("index", {
         new Command({
           name: "영역 선택(구현X)",
           icon: "section",
+          cursor: "crosshair",
+          isDrawable: false,
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},
@@ -174,6 +187,8 @@ export const useStore = defineStore("index", {
         new Command({
           name: "이동(구현X)",
           icon: "move",
+          cursor: "move",
+          isDrawable: false,
           commandable: {
             clickStart: () => {},
             clickEnd: () => {},


### PR DESCRIPTION
커서 프리뷰가 추가되었습니다.
그리는 동작일 경우, 캔버스에 선택된 색상으로 그려질 위치에 미리보기가 등장합니다.
커서 이미지 또한 변경되었습니다.